### PR TITLE
Fixed Conditional Check: TypeError: '>' not supported between instanc…

### DIFF
--- a/roles/cmk_host_plugins/tasks/Linux-main.yml
+++ b/roles/cmk_host_plugins/tasks/Linux-main.yml
@@ -17,7 +17,7 @@
   with_items: "{{ CMK_PLUGINS }}"
   loop_control:
     loop_var: needed_plugin
-  when: CMK_PLUGINS > 0
+  when: CMK_PLUGINS|length>0
 
 - name: Get obsolete installed Plugins
   set_fact:


### PR DESCRIPTION
…es of 'list' and 'int' in python3

In Python3 you can no longer compare lists with that operator 

```
bkuhn@klappbuch~
 % python
Python 2.7.15 (default, Sep 18 2018, 20:30:39)
[GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.10.43.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> [1,2] > 2
True
>>>
bkuhn@klappbuch~
 % python3
Python 3.7.0 (default, Oct  2 2018, 09:18:58)
[Clang 10.0.0 (clang-1000.11.45.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> [1,2] > 3
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: '>' not supported between instances of 'list' and 'int'
>>>
```

Same for the obsolete_plugin condition, but don't have the time to investigate that this evening :)