### PR TITLE
fix various issues in checkmk_changes.py

### DIFF
--- a/roles/cmk_host_registration/library/checkmk_changes.py
+++ b/roles/cmk_host_registration/library/checkmk_changes.py
@@ -91,9 +91,8 @@ from ansible.module_utils.checkmk_api import Changes
 class CallChanges:
     def __init__(self, session):
         self.session = session
-        self.hostname = session.hostname
 
-    def activate(self, payload):
+    def activate(self, payload, ansible):
         result = self.session.activate(payload=payload)
         result_output = result['result']
 
@@ -133,18 +132,18 @@ def main():
         verify=ansible.params['validate_certs'],))
 
     payload = {
-        'allow_foreign_changes': ansible.params['allow_foreign_changes']
+        'allow_foreign_changes': '1' if ansible.params['allow_foreign_changes'] == 'yes' else '0'
         }
 
     if ansible.params['comments']:
-        payload['comments'] = ansible.params['comments']
+        payload['comment'] = ansible.params['comments']
     if sites:
         payload['sites'] = sites
         payload['mode'] = 'specific'
     else:
         payload['mode'] = 'dirty'
     
-    changed, result = changes.activate(payload)    
+    changed, result = changes.activate(payload, ansible)    
 
     ansible_result = dict(
         sites=sites,


### PR DESCRIPTION
1. Since `Changes()` doesn't have a hostname attribute, this cannot be accessed in `CallChanges()`. Since self.hostname doesn't seem to be used in `CallChanges()` except for the assignment, I have removed it. This fixes #4.

2. `CallChanges().activate()` requires access to the created `AnsibleModule()` object, since it might send back fail_json data. Added the object as parameter. Not sure if this is the best way, but it fixes the issue. 

3. The `allow_foreign_changes parameter` (checkmk-api) requires '0' or '1', not 'yes' or 'no'. Added a translation between those.
4. The `comment` parameter (checkmk-api) is called 'comment' without the 's'

In regards to 3 and 4, see documentation here: https://checkmk.com/cms_web_api_references.html#activate_changes. I tested those changes against `1.6.0p17` with `ansible 2.9.13` and `Python 3.8.5` (ansible control node/localhost).