### PR TITLE
rpm are not always signed

### DIFF
--- a/roles/cmk_host_agent/tasks/RedHat-tasks.yml
+++ b/roles/cmk_host_agent/tasks/RedHat-tasks.yml
@@ -11,3 +11,4 @@
   yum:
       name: "{{ cmk_agent.file.rpm }}"
       state: present
+      disable_gpg_check: yes


### PR DESCRIPTION
The check_mk_agent rpm is not always signed (never in RAW), to install it we need to disable gpg_check