### PR TITLE
improve python code

### DIFF
--- a/roles/cmk_host_registration/library/checkmk_changes.py
+++ b/roles/cmk_host_registration/library/checkmk_changes.py
@@ -38,10 +38,8 @@ options:
     allow_foreign_changes:
         description: Sometimes other users made changes meanwhile. This option specifies if the changes should be activated if there are configuration changes from other users. 
         required: false
-        default: no
-        choices:
-            - yes
-            - no
+        default: False
+        type: bool
     comment:
         description: You can optionally add a comment to this activation. 
         required: false
@@ -49,10 +47,8 @@ options:
     validate_certs:
         description: Check SSL certificate
         required: false
-        default: yes
-        choices:
-            - yes
-            - no
+        default: True
+        type: bool
 '''
 
 EXAMPLES = '''
@@ -91,9 +87,8 @@ from ansible.module_utils.checkmk_api import Changes
 class CallChanges:
     def __init__(self, session):
         self.session = session
-        self.hostname = session.hostname
 
-    def activate(self, payload):
+    def activate(self, payload, ansible):
         result = self.session.activate(payload=payload)
         result_output = result['result']
 
@@ -114,9 +109,9 @@ def main():
         password=dict(type='str', required=True, no_log=True),
         # Optional
         sites=dict(type='list', default=None),
-        allow_foreign_changes=dict(type='str', default='no', choices=['yes', 'no']),
+        allow_foreign_changes=dict(type='bool', default=True),
         comments=dict(type='str', default=None),
-        validate_certs=dict(type='str', default='yes', choices=['yes', 'no']),
+        validate_certs=dict(type='bool', default=True),
         )
 
     ansible = AnsibleModule(
@@ -137,14 +132,14 @@ def main():
         }
 
     if ansible.params['comments']:
-        payload['comments'] = ansible.params['comments']
+        payload['comment'] = ansible.params['comments']
     if sites:
         payload['sites'] = sites
         payload['mode'] = 'specific'
     else:
         payload['mode'] = 'dirty'
-    
-    changed, result = changes.activate(payload)    
+
+    changed, result = changes.activate(payload, ansible)
 
     ansible_result = dict(
         sites=sites,

--- a/roles/cmk_host_registration/library/checkmk_host.py
+++ b/roles/cmk_host_registration/library/checkmk_host.py
@@ -47,10 +47,18 @@ options:
     validate_certs:
         description: Check SSL certificate
         required: false
-        default: yes
-        choices:
-            - yes
-            - no
+        default: True
+        type: bool
+    service_discovery:
+        description: Start the service discovery after adding/changing the host
+        required: false
+        default: True
+        type: bool
+    activate_changes:
+        description: Activate the changes
+        required: false
+        default: True
+        type: bool
 '''
 
 EXAMPLES = '''
@@ -139,7 +147,7 @@ class CallHost:
                 return True, self.session.edit(payload=payload)['result']
 
             # We need to figure what to do with every custom key
-            for key, value in existing_attr.iteritems():
+            for key, value in existing_attr.items():
                 if key not in needed_attr:
                     unset_attr.append(key)
                 elif value != needed_attr[key]:
@@ -168,9 +176,9 @@ def main():
         # Optional
         attributes=dict(type='dict', default={}),
         folder=dict(type='str', default=''),
-        validate_certs=dict(type='str', default='yes', choices=['yes', 'no']),
-        discover_services=dict(type='str', default='no', choices=['yes', 'no']),
-        activate_changes=dict(type='str', default='no', choices=['yes', 'no']),
+        validate_certs=dict(type='bool', default=True),
+        discover_services=dict(type='bool', default=True),
+        activate_changes=dict(type='bool', default=True),
         # Meta
         state=dict(type='str', default='present', choices=['present', 'absent']),
         )
@@ -220,7 +228,7 @@ def main():
         result=result,
         )
 
-    if discover != 'no' and changed == True:
+    if discover and changed == True:
         service = Services(
             ansible.params['url'],
             ansible.params['user'],
@@ -233,7 +241,7 @@ def main():
             status=discovery['result_code'],
             )
 
-    if activate != 'no' and changed == True:
+    if activate and changed == True:
         changes = Changes(
             ansible.params['url'],
             ansible.params['user'],

--- a/roles/cmk_host_registration/library/checkmk_services.py
+++ b/roles/cmk_host_registration/library/checkmk_services.py
@@ -46,10 +46,8 @@ options:
     validate_certs:
         description: Check SSL certificate
         required: false
-        default: yes
-        choices:
-            - yes
-            - no
+        default: True
+        type: bool
 '''
 
 EXAMPLES = '''
@@ -113,7 +111,7 @@ def main():
         name=dict(type='str', required=True),
         # Optional
         mode=dict(type='str', default='new', choices=['']),
-        validate_certs=dict(type='str', default='yes', choices=['yes', 'no']),
+        validate_certs=dict(type='bool', default=True),
         )
 
     ansible = AnsibleModule(

--- a/roles/cmk_host_registration/module_utils/checkmk_api.py
+++ b/roles/cmk_host_registration/module_utils/checkmk_api.py
@@ -27,7 +27,7 @@ class WebAPI(object):
             payload['request'] = repr(request)
 
         try:
-            response = requests.get(self.url, params=payload, verify=self.verify, timeout=5)
+            response = requests.get(self.url, params=payload, verify=self.verify, timeout=30)
             return ast.literal_eval(response.text)
         except:
             raise


### PR DESCRIPTION
Hey there,
I made some changes to the modules of the role cmk_host_registration.

This is based on the pull request of @networkjanitor in #6. (Number 1, 2 and 4 out of that pull request).


1) I replaced all replace yes/no string options with actual booleans. This fixes #3, #4 and #5.

    The python code for checking certificates expects a boolean or a string for the location of the ca-certs file.
    A 'yes'  is interpreted as string and the validation fails since there is no file named "yes".

2) I increased the timeout from 5 to 30 seconds since activation of changes runs on my system for at least 4.8 seconds. In the future there should be a parameter for that

3) There was a dict.iteritems  in handling attributes. I replaced that with dict.items for python3 compability.

4) I added some doc strings for the previously undocumented parameters  discover_services and activate_changes since I missed that. In the future there should be more comments about that in the role about that


Thanks.

Florian