### PR TITLE
Fix role name in example

### DIFF
--- a/ansible-example.yml
+++ b/ansible-example.yml
@@ -15,4 +15,4 @@
   gather_facts: smart
   tags: [all, register]
   roles:
-      - cmk_site_host_registration
+      - cmk_host_registration


### PR DESCRIPTION
Role name wrong in ansible-example.yml file.