### PR TITLE
Added variable cmk_validate_certs to allow disabling the certificate verification

### DIFF
--- a/roles/cmk_host_registration/defaults/main.yml
+++ b/roles/cmk_host_registration/defaults/main.yml
@@ -4,3 +4,4 @@ cmk_site_url: "http://192.168.56.1/mysite"
 cmk_site_user: automation
 cmk_site_password: myautomationpassword
 cmk_site_default_folder: "ansible"
+cmk_validate_certs: true

--- a/roles/cmk_host_registration/handlers/main.yml
+++ b/roles/cmk_host_registration/handlers/main.yml
@@ -7,4 +7,5 @@
     password: "{{ cmk_site_password }}"
     allow_foreign_changes: yes
     comments: 'Changes made by Ansible'
+    validate_certs: "{{ cmk_validate_certs }}"
   delegate_to: localhost

--- a/roles/cmk_host_registration/tasks/main.yml
+++ b/roles/cmk_host_registration/tasks/main.yml
@@ -17,6 +17,7 @@
     folder: "{{ cmk_site_default_folder }}/{{ OS }}"
     state: present
     discover_services: yes
+    validate_certs: "{{ cmk_validate_certs }}"
   delegate_to: localhost
   notify:
     - activate changes


### PR DESCRIPTION
The underlying `checkmk_changes` and `checkmk_host` modules allow to disable the certificate verification.

This PR allows to set a variable `cmk_validate_certs` at role level.